### PR TITLE
Update lotj_channels.xml

### DIFF
--- a/lotj_channels.xml
+++ b/lotj_channels.xml
@@ -43,7 +43,7 @@ USAGE:
   <trigger enabled="n" name="exclaim1" match="*exclaim*'*'" regexp="n" omit_from_output="n" script="untagged_info" sequence="100" />
   <trigger enabled="n" name="exclaim2" match="'*'*exclaim*" regexp="n" omit_from_output="n" script="untagged_info" sequence="100" />
   <trigger enabled="n" name="clan" match="*{*}<*>[*]*:*" regexp="n" omit_from_output="n" script="untagged_info" sequence="100" />
-  <trigger enabled="n" name="clan2" match="$\[(Outgoing|Incoming) Transmission (to|from) (.*)\](.*)" regexp="y" omit_from_output="n" script="untagged_info" sequence="100" />
+  <trigger enabled="n" name="clan2" match="\[(Outgoing|Incoming) Transmission (to|from) (.*)\](.*)" regexp="y" omit_from_output="n" script="untagged_info" sequence="100" />
   <trigger enabled="n" name="comms" match="CommNet*:*" regexp="n" omit_from_output="n" script="untagged_info" sequence="100" />
   <trigger enabled="n" name="broadcast" match="Broadcasting Network*:*" regexp="n" omit_from_output="n" script="untagged_info" sequence="100" />
   
@@ -163,6 +163,7 @@ SetTriggerOption("ask2", "enabled", show_say)
 SetTriggerOption("exclaim1", "enabled", show_say)
 SetTriggerOption("exclaim2", "enabled", show_say)
 SetTriggerOption("clan", "enabled", show_clan)
+SetTriggerOption("clan2", "enabled", show_clan)
 SetTriggerOption("comms", "enabled", show_comms)
 SetTriggerOption("broadcast", "enabled", show_broadcast)
 SetTriggerOption("buzz", "enabled", show_buzz)
@@ -182,6 +183,7 @@ SetTriggerOption("ask2", "omit_from_output", say_echo)
 SetTriggerOption("exclaim1", "omit_from_output", say_echo)
 SetTriggerOption("exclaim2", "omit_from_output", say_echo)
 SetTriggerOption("clan", "omit_from_output", clan_echo)
+SetTriggerOption("clan2", "omit_from_output", clan_echo)
 SetTriggerOption("comms", "omit_from_output", comms_echo)
 SetTriggerOption("ooc", "omit_from_output", ooc_echo)
 SetTriggerOption("immooc", "omit_from_output", ooc_echo)


### PR DESCRIPTION
The "Incoming/Ougoing" part of clan messaging was not going to the output window. It's convenient to know if a message is internal or external at a glance. I think your intention was for this to show up in the window, since there is a trigger for it. The biggest obstacle is the "$" in the regular expression which, I'm sure you already know, evaluates as "end of line." With a "$" at the beginning of the trigger string, it will never fire.

However, that alone is not a enough to make the [incoming/outgoing] line show up. I had to add some SetTriggerOption lines for clan2 as well, basically just mirroring what was done for say1/say2.
